### PR TITLE
Update base-image-url-es

### DIFF
--- a/.github/workflows/build_img_es.yml
+++ b/.github/workflows/build_img_es.yml
@@ -53,7 +53,7 @@ jobs:
           CONSTRAINTS: "https://github.com/OpenVoiceOS/ovos-releases/raw/refs/heads/main/constraints-alpha.txt"
           MYCROFT_CONFIG_FILES: "mycroft.conf,mycroft_es.conf"
         with:
-          base-image-url: https://github.com/TigreGotico/raspOVOS/releases/download/raspOVOS-bookworm-arm64-lite-2024-12-19/raspOVOS-bookworm-arm64-lite.img.xz
+          base-image-url: https://github.com/TigreGotico/raspOVOS/releases/download/raspOVOS-bookworm-arm64-lite-2024-12-27/raspOVOS-bookworm-arm64-lite.img.xz
           image-path: raspOVOS-spanish-bookworm-arm64-lite.img
           compress-with-xz: true
           shrink: true


### PR DESCRIPTION
This PR updates the base-image-url in `build_img_es.yml` to reflect the latest release.