### PR TITLE
fix: repair local build entrypoints (local_build.sh / local_build_all.sh)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,21 @@
+name: ShellCheck
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
+
+      - name: Lint shell scripts
+        run: ./scripts/ci/run_shellcheck.sh

--- a/local_build.sh
+++ b/local_build.sh
@@ -19,7 +19,7 @@ BUILD_DIR="/tmp/rpi-image-modifier-raspOVOS"
 RASPOVOS_DIR="$(pwd -P)"  # raspOVOS repo
 
 # === REQUIRED ARGUMENTS ===
-script_path="build_raspOVOS.sh" # relative path
+script_path="build_raspOVOS_base_lite.sh" # relative path
 
 base_image="https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2025-05-13/2025-05-13-raspios-bookworm-arm64-lite.img.xz"
 image_maxsize="8G"
@@ -31,9 +31,44 @@ compress_with_xz=false
 extra_xz_args=""
 shell="/bin/bash"
 
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Build a raspOVOS image locally (equivalent to the GitHub Actions build).
+Needs root via sudo, qemu-user-static binfmt, and systemd-nspawn.
+
+Options:
+  --script-path PATH        Provisioning script to run inside the image
+                            (default: build_raspOVOS_base_lite.sh; lang images
+                            use lang_builds/{lite,hybrid,offline}/build_raspOVOS_<lang>.sh)
+  --base-image URL|FILE     Base image to modify (default: pinned Raspberry Pi OS Lite)
+  --image-maxsize SIZE      Grow image to SIZE before provisioning (default: 8G)
+  --image-output-path PATH  Output filename (default: raspovos-dev-bookworm-arm64-lite.img.xz)
+  --shrink                  Shrink the image with PiShrink
+  --compress-with-xz        Compress the output with xz
+  --extra-xz-args ARGS      Extra arguments for xz
+  --shell SHELL             Shell used inside the container (default: /bin/bash)
+  -h, --help                Show this help and exit
+EOF
+}
+
+check_deps() {
+    local missing=()
+    local dep
+    for dep in losetup parted e2fsck resize2fs systemd-nspawn wget file fallocate xz; do
+        command -v "$dep" >/dev/null 2>&1 || missing+=("$dep")
+    done
+    [[ -f /usr/bin/qemu-aarch64-static ]] || missing+=("qemu-aarch64-static (qemu-user-static)")
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        error "Missing dependencies: ${missing[*]}"
+    fi
+}
+
 # === Parse arguments ===
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        -h|--help) usage; exit 0 ;;
         --script-path) script_path="$2"; shift ;;
         --base-image) base_image="$2"; shift ;;
         --image-maxsize) image_maxsize="$2"; shift ;;
@@ -59,6 +94,13 @@ if [[ ! -f "$script_path" ]]; then
     error "Script not found: $script_path"
 fi
 
+check_deps
+
+# resolve local base images to absolute paths before we cd into BUILD_DIR
+if [[ ! "$base_image" =~ ^https?:// && -f "$base_image" ]]; then
+    base_image="$(realpath "$base_image")"
+fi
+
 if $shrink_image; then
     sudo wget -q -O /usr/local/bin/pishrink.sh https://raw.githubusercontent.com/Drewsif/PiShrink/master/pishrink.sh
     sudo chmod +x /usr/local/bin/pishrink.sh
@@ -73,8 +115,7 @@ if [[ "$base_image" =~ ^https?:// ]]; then
     wget -q -O rpi.img "${base_image}"
 elif [[ -f "$base_image" ]]; then
     echo_green "Copying local image: ${base_image}"
-    #cp -v "$base_image" rpi.img
-    #ln -s "$base_image" rpi.img
+    cp -v "$base_image" rpi.img
 else
     error "Invalid base_image path or URL: ${base_image}"
 fi

--- a/local_build.sh
+++ b/local_build.sh
@@ -7,11 +7,11 @@
 set -e
 
 echo_green() {
-    echo -e "\x1B[1m>>> \x1B[0m\x1B[32;1m$@\x1B[0m"
+    echo -e "\x1B[1m>>> \x1B[0m\x1B[32;1m$*\x1B[0m"
 }
 
 error() {
-    echo -e "\x1B[31;1mERROR: $@\x1B[0m"
+    echo -e "\x1B[31;1mERROR: $*\x1B[0m"
     exit 1
 }
 

--- a/local_build_all.sh
+++ b/local_build_all.sh
@@ -7,15 +7,15 @@
 set -e
 
 echo_green() {
-    echo -e "\x1B[1m>>> \x1B[0m\x1B[32;1m$@\x1B[0m"
+    echo -e "\x1B[1m>>> \x1B[0m\x1B[32;1m$*\x1B[0m"
 }
 
 echo_yellow() {
-    echo -e "\x1B[1m>>> \x1B[0m\x1B[33;1m$@\x1B[0m"
+    echo -e "\x1B[1m>>> \x1B[0m\x1B[33;1m$*\x1B[0m"
 }
 
 error() {
-    echo -e "\x1B[31;1mERROR: $@\x1B[0m"
+    echo -e "\x1B[31;1mERROR: $*\x1B[0m"
     exit 1
 }
 

--- a/local_build_all.sh
+++ b/local_build_all.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-# This script is equivalent to the github action but tuned to run locally
-# if you cloned the raspOVOS repo you can use this script as long as qemu is properly setup in your machine
-# NOTE: runs local_build.sh for all language specific images
+# This script is equivalent to the github actions but tuned to run locally.
+# It drives local_build.sh: first the base image (build_raspOVOS_base_lite.sh,
+# optionally build_raspOVOS_base_full.sh on top), then the per-language images
+# from lang_builds/{lite,hybrid,offline}/.
+# Requires qemu-user-static + systemd-nspawn, see local_build.sh --help.
 
 set -e
 
@@ -19,44 +21,81 @@ error() {
     exit 1
 }
 
+usage() {
+    cat <<EOF
+Usage: $0 [--variant lite|hybrid|offline] [--langs "xx yy"] [--base-image URL|FILE] [--skip-base]
+
+Builds the raspOVOS base image, then the per-language images for one variant.
+
+Options:
+  --variant VARIANT    Which lang_builds variant to build (default: lite)
+  --langs "xx yy"      Space-separated language codes (default: every script
+                       present in lang_builds/<variant>/)
+  --base-image PATH    Base image for the base build (default: local_build.sh's
+                       pinned Raspberry Pi OS Lite URL)
+  --skip-base          Reuse an existing local base image instead of building it;
+                       requires --base-image pointing at a raspOVOS base image
+  -h, --help           Show this help and exit
+EOF
+}
+
 BASEDIR="$(pwd -P)"
+variant="lite"
+langs=""
+base_image=""
+skip_base=false
 
-LANGS=(ca gl en es eu pt nl de it multilingual)
-AUDIO_BASE="rpi-bookworm-arm64-audio-base.img.xz"
-RASPOVOS_BASE="raspOVOS-bookworm-arm64-DEV.img.xz"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help) usage; exit 0 ;;
+        --variant) variant="$2"; shift ;;
+        --langs) langs="$2"; shift ;;
+        --base-image) base_image="$2"; shift ;;
+        --skip-base) skip_base=true ;;
+        *) echo "Unknown option: $1"; usage; exit 1 ;;
+    esac
+    shift
+done
 
-echo_green "Starting build: Audio base image"
-if /bin/bash ./build.sh --script-path build_audio_base.sh --image-output-path "$AUDIO_BASE"; then
-    echo_green "Audio base image built successfully"
-else
-    error "Failed to build audio base image"
+[[ -d "lang_builds/$variant" ]] || error "Unknown variant: $variant (expected lite, hybrid or offline)"
+
+if [[ -z "$langs" ]]; then
+    langs="$(find "lang_builds/$variant" -name 'build_raspOVOS_*.sh' -printf '%f\n' \
+        | sed 's/build_raspOVOS_\(.*\)\.sh/\1/' | sort | tr '\n' ' ')"
 fi
 
-echo_green "Starting build: raspOVOS base image"
-if /bin/bash ./build.sh --script-path build_raspOVOS.sh --image-output-path "$RASPOVOS_BASE" --base-image "$BASEDIR/$AUDIO_BASE"; then
-    echo_green "raspOVOS base image built successfully"
+RASPOVOS_BASE="raspOVOS-DEV-bookworm-arm64-lite.img"
+
+if $skip_base; then
+    [[ -f "$base_image" ]] || error "--skip-base requires --base-image pointing at an existing raspOVOS base image"
+    RASPOVOS_BASE="$base_image"
+    echo_yellow "Skipping base build, reusing: $RASPOVOS_BASE"
 else
-    error "Failed to build raspOVOS base image"
+    echo_green "Starting build: raspOVOS base image (lite)"
+    base_args=()
+    [[ -n "$base_image" ]] && base_args=(--base-image "$base_image")
+    /bin/bash ./local_build.sh --script-path build_raspOVOS_base_lite.sh \
+        --image-output-path "$RASPOVOS_BASE" "${base_args[@]}" \
+        || error "Failed to build raspOVOS base image"
+    if [[ "$variant" == "offline" ]]; then
+        echo_green "Starting build: raspOVOS base image (full, needed for offline langs)"
+        /bin/bash ./local_build.sh --script-path build_raspOVOS_base_full.sh \
+            --image-output-path "$RASPOVOS_BASE" --base-image "$BASEDIR/$RASPOVOS_BASE" \
+            || error "Failed to build raspOVOS full base image"
+    fi
 fi
 
+for lang in $langs; do
+    SCRIPT="lang_builds/$variant/build_raspOVOS_${lang}.sh"
+    OUTPUT="raspOVOS-bookworm-arm64-${variant}-${lang}.img"
 
-
-LANGS=(ca gl en es eu pt nl de it multilingual)
-RASPOVOS_BASE="https://github.com/OpenVoiceOS/raspOVOS/releases/download/raspOVOS-DEV-bookworm-arm64-lite-2025-05-29/raspOVOS-DEV-bookworm-arm64-lite.img.xz"
-
-for lang in "${LANGS[@]}"; do
-    IMG_VAR="RASPOVOS_${lang}"
-    IMG_PATH="${!IMG_VAR}"
-    SCRIPT="build_raspOVOS_${lang}.sh"
-
-    echo_green "Processing language: $lang"
+    echo_green "Processing language: $lang ($variant)"
     if [[ -f "$SCRIPT" ]]; then
         echo_yellow "Running build script: $SCRIPT"
-        if /bin/bash ./build.sh --script-path "$SCRIPT" --image-output-path "$IMG_PATH" --base-image "$RASPOVOS_BASE"; then
-            echo_green "Build for $lang completed successfully"
-        else
-            error "Build failed for $lang"
-        fi
+        /bin/bash ./local_build.sh --script-path "$SCRIPT" \
+            --image-output-path "$OUTPUT" --base-image "$BASEDIR/$RASPOVOS_BASE" \
+            || error "Build failed for $lang"
+        echo_green "Build for $lang completed successfully: $OUTPUT"
     else
         echo_yellow "Script $SCRIPT not found, skipping build for $lang"
     fi

--- a/overlays/base/usr/local/bin/ovos-audio-diagnostics
+++ b/overlays/base/usr/local/bin/ovos-audio-diagnostics
@@ -156,12 +156,12 @@ echo ""
 echo "# Available audio outputs:"
 ls_sinks
 
-if $SOUND_SERVER == "alsa"; then
+if [ "$SOUND_SERVER" = "alsa" ]; then
     # no sinks, guess we |  awk '/Video/ {exit} {print}' | could print asound.rc
     exit 0
 fi
 
-if $SOUND_SERVER == "pulseaudio"; then
+if [ "$SOUND_SERVER" = "pulseaudio" ]; then
     echo "pulseaudio support not implemented"
     exit 1
 fi

--- a/scripts/ci/run_shellcheck.sh
+++ b/scripts/ci/run_shellcheck.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Lint every shell script in the repo: *.sh files plus extensionless scripts
+# (overlays/**/usr/local/bin, usr/libexec) identified by a sh/bash shebang.
+# Severity gate is set in .shellcheckrc; run locally with:
+#   ./scripts/ci/run_shellcheck.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+mapfile -t sh_files < <(find . -path ./.git -prune -o -name '*.sh' -print)
+mapfile -t shebang_files < <(grep -rlI --exclude-dir=.git --exclude='*.sh' -m1 -E '^#!.*\b(ba)?sh\b' . || true)
+
+# Gate at error severity for now; tighten to warning once the backlog is
+# fixed (one directory per PR).
+echo "Checking ${#sh_files[@]} *.sh files and ${#shebang_files[@]} shebang scripts"
+shellcheck --severity=error "${sh_files[@]}" "${shebang_files[@]}"
+echo "shellcheck OK"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # TODO - flesh out and include in image as /usr/local/bin/ovos-update
 #  also see current alias in .bash_aliases
 


### PR DESCRIPTION
## What
Makes local image building actually work again:

- `local_build.sh`: default `--script-path` pointed at a nonexistent `build_raspOVOS.sh` → now `build_raspOVOS_base_lite.sh`. The local-file base-image branch validated the file then did nothing (the `cp` was commented out) → now copies, with paths resolved via `realpath` before the cwd change. Adds `--help` and fail-fast host dependency checks (losetup, systemd-nspawn, qemu-aarch64-static, parted, …).
- `local_build_all.sh`: rewritten. It invoked a nonexistent `build.sh` with nonexistent provisioning scripts (`build_audio_base.sh`, `build_raspOVOS.sh`, `build_raspOVOS_<lang>.sh` at repo root), an empty `--image-output-path` (broken indirection), and a dead 2025-05-29 release URL. Now drives `local_build.sh` against the real layout: base lite (+ full for offline) → `lang_builds/<variant>/build_raspOVOS_<lang>.sh`, with `--variant`, `--langs`, `--base-image`, `--skip-base` and `--help`.

## Validation
- `bash -n` both scripts; `--help` exits 0 without root; bogus `--variant` fails with a clear error.
- Every script filename referenced now exists in the repo.
- `./scripts/ci/run_shellcheck.sh` green.

Stacked on #153 (shares the shellcheck script + $*-in-string fixes); will rebase once that merges.

Part of the raspOVOS revival roadmap, Phase 0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)