### PR TITLE
docs: add CHANGELOG, CONTRIBUTING and roadmap-task issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap-task.md
+++ b/.github/ISSUE_TEMPLATE/roadmap-task.md
@@ -1,0 +1,30 @@
+---
+name: Roadmap task
+about: A hand-off-ready task spec for the raspOVOS revival roadmap
+title: "[roadmap] "
+labels: roadmap
+---
+
+## What
+
+<!-- One-sentence outcome. Exact files to touch. Explicit non-goals. -->
+
+## How
+
+<!-- Numbered steps with exact commands. Name an existing file to imitate. -->
+
+## Test
+
+<!-- Commands to run locally + which CI check must go green. New assertions to add. -->
+
+## Document
+
+<!-- Which doc/README/CHANGELOG section to update (path + heading). -->
+
+## Validate (Definition of Done)
+
+- [ ] `./scripts/ci/run_shellcheck.sh` green
+- [ ] Relevant CI checks green
+- [ ] For new test infra: proven to fail on an injected defect (link the red run)
+- [ ] Draft PR into `dev`, conventional commit message
+- [ ] CHANGELOG / docs updated if user-facing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+Notable changes to the raspOVOS images and build system. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); entries land under
+**Unreleased** and move into a dated section when a release is published
+(releases are tagged `raspOVOS-<variant>-<YYYY-MM-DD>`).
+
+## [Unreleased]
+
+### Added
+- `LICENSE` (Apache-2.0), `CHANGELOG.md`, `CONTRIBUTING.md`
+- ShellCheck CI gate over all shell scripts (`scripts/ci/run_shellcheck.sh`)
+
+### Fixed
+- `ovos-audio-diagnostics` executed the sound-server name as a command
+  instead of comparing it, so its alsa/pulseaudio fallbacks never ran
+- `local_build.sh` / `local_build_all.sh` pointed at nonexistent build
+  scripts and could not run; both are functional again with `--help`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to raspOVOS
+
+raspOVOS builds the official OpenVoiceOS Raspberry Pi images. This is an
+image-build pipeline, not a Python package: the "code" is provisioning shell
+scripts, filesystem overlays, and GitHub Actions workflows.
+
+## Ground rules
+
+- **Branches:** work on a feature branch, open a **draft PR into `dev`**.
+  Mark it ready only when CI is green. Never push to `dev` directly.
+- **Commits:** use [conventional commits](https://www.conventionalcommits.org/)
+  (`feat:`, `fix:`, `ci:`, `docs:`, …). Breaking changes to the image contract
+  (user name, venv path, unit names, `/opt/ovos/*`) must use `feat!:` and call
+  out **BREAKING** in the PR body — downstream images build on top of raspOVOS.
+- **One overlay layer per PR:** never edit two `overlays/` layers
+  (`base`, `base_gui`, `base_ovos`, `base_ovos_offline`, per-language) in the
+  same PR.
+- **Update `CHANGELOG.md`** (Unreleased section) in any PR that changes what
+  ships in an image.
+
+## Shell style
+
+Every `*.sh` file and every extensionless shebang script under `overlays/`
+must pass ShellCheck at error severity:
+
+```bash
+./scripts/ci/run_shellcheck.sh
+```
+
+CI runs exactly this script — if it is green locally, it is green in CI.
+
+## Building locally
+
+```bash
+./local_build.sh --help        # single image (base or one provisioning script)
+./local_build_all.sh --help    # base + all language images for one variant
+```
+
+Requirements: `qemu-user-static` (binfmt), `systemd-container`
+(systemd-nspawn), `parted`, `xz`, and root via sudo.
+
+## Releases
+
+Images are built by the GitHub Actions workflows and published to GitHub
+Releases with date-tagged names (`raspOVOS-<variant>-<YYYY-MM-DD>`). Dev base
+images use the `raspOVOS-DEV-` prefix and feed the language image builds.


### PR DESCRIPTION
## What
- `CHANGELOG.md` — Keep-a-Changelog format; entries land under Unreleased and move into dated sections at release.
- `CONTRIBUTING.md` — branch/PR rules (draft PRs into dev), conventional commits, BREAKING flag for image-contract changes, one-overlay-layer-per-PR rule, shell style (shellcheck via `scripts/ci/run_shellcheck.sh`), local build pointers.
- `.github/ISSUE_TEMPLATE/roadmap-task.md` — the What/How/Test/Document/Validate template every roadmap task uses.

## Validation
Files exist and render on GitHub; no behavior change.

Note: CONTRIBUTING references the shellcheck script and repaired local-build flags from #153/#154 — merge those first (or together).

Part of the raspOVOS revival roadmap, Phase 0.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)