### PR TITLE
fix: harden CI tier internals (bind mounts, allowlist filtering, manifest quoting)

### DIFF
--- a/scripts/ci/chroot_checks.sh
+++ b/scripts/ci/chroot_checks.sh
@@ -30,6 +30,7 @@ c_fail() { echo -e "\x1B[31;1mCHECK FAIL: $*\x1B[0m" >&2; ERRORS=$((ERRORS + 1))
 
 trap cleanup_image EXIT
 mount_image "$IMG" rw   # rw: we drop qemu-aarch64-static in, removed on exit
+bind_system_mounts
 
 cp /usr/bin/qemu-aarch64-static "$MNT/usr/bin/" 2>/dev/null || true
 

--- a/scripts/ci/dev_shell.sh
+++ b/scripts/ci/dev_shell.sh
@@ -16,6 +16,7 @@ command -v systemd-nspawn >/dev/null 2>&1 || fail "systemd-container is required
 
 trap cleanup_image EXIT
 mount_image "$IMG" rw
+# nspawn manages its own /proc etc.; no bind_system_mounts needed here
 
 cp /usr/bin/qemu-aarch64-static "$MNT/usr/bin/"
 log "Entering image (exit the shell to unmount)"

--- a/scripts/ci/image_mount.sh
+++ b/scripts/ci/image_mount.sh
@@ -53,6 +53,16 @@ mount_image() {
     log "Mounted rootfs at $MNT"
 }
 
+# Bind-mount the host's /proc, /sys, /dev into the image rootfs so chrooted
+# processes work (python multiprocessing, /dev/null, …). cleanup_image's
+# `umount -R` tears these down with the rest.
+bind_system_mounts() {
+    mount --bind /proc "$MNT/proc"
+    mount --bind /sys "$MNT/sys"
+    mount --bind /dev "$MNT/dev"
+    mount --bind /dev/pts "$MNT/dev/pts"
+}
+
 cleanup_image() {
     set +e
     if [[ -n "$MNT" && -d "$MNT" ]]; then

--- a/scripts/ci/qemu_boot_test.sh
+++ b/scripts/ci/qemu_boot_test.sh
@@ -86,7 +86,10 @@ log "Checking journal errors against allowlist"
 JOURNAL_ERR="$ARTIFACTS/journal-err.log"
 sed -n '/JOURNAL-ERR-BEGIN/,/JOURNAL-ERR-END/p' "$SERIAL_LOG" \
     | grep -vE 'JOURNAL-ERR-(BEGIN|END)|^-- ' > "$JOURNAL_ERR" || true
-UNEXPECTED="$(grep -vEf "${SCRIPT_DIR}/journal-allowlist.txt" "$JOURNAL_ERR" | grep -vE '^\s*$' || true)"
+# strip comments/blank lines from the allowlist first — grep -f treats every
+# line as a live regex and an empty line would match (and suppress) everything
+ALLOW_PATTERNS="$(grep -vE '^\s*(#|$)' "${SCRIPT_DIR}/journal-allowlist.txt")"
+UNEXPECTED="$(grep -vEf <(echo "$ALLOW_PATTERNS") "$JOURNAL_ERR" | grep -vE '^\s*$' || true)"
 if [[ -n "$UNEXPECTED" ]]; then
     echo "$UNEXPECTED" >&2
     fail "unexpected journal errors (add benign ones to journal-allowlist.txt WITH a why-comment)"

--- a/scripts/write_build_manifest.sh
+++ b/scripts/write_build_manifest.sh
@@ -16,29 +16,36 @@ VENV_PIP="${VENV_PIP:-/home/${OVOS_USER:-ovos}/.venvs/ovos/bin/pip}"
 
 mkdir -p "$(dirname "$OUT")"
 
-PY_ABI="$(python3 -c 'import sys; print(f"cp{sys.version_info[0]}{sys.version_info[1]}")')"
-OS_PRETTY="$(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)"
-BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-FROZEN="$("$VENV_PIP" freeze --all 2>/dev/null | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().splitlines()))')"
+# values reach python via the environment (quoted heredoc): no shell
+# interpolation into python source, no quoting/injection hazards
+M_PY_ABI="$(python3 -c 'import sys; print(f"cp{sys.version_info[0]}{sys.version_info[1]}")')"
+M_OS_PRETTY="$(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)"
+M_BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+M_FROZEN="$("$VENV_PIP" freeze --all 2>/dev/null || true)"
 
-RUN_URL=""
+M_RUN_URL=""
 if [[ -n "${GITHUB_RUN_ID:-}" && -n "${GITHUB_REPOSITORY:-}" ]]; then
-    RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+    M_RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 fi
 
-python3 - "$OUT" <<PYEOF
-import json, sys
+export M_PY_ABI M_OS_PRETTY M_BUILD_DATE M_FROZEN M_RUN_URL VARIANT
+export M_LANG="${LANG_CODE:-}" M_CONSTRAINTS="${CONSTRAINTS:-}" \
+       M_BASE_URL="${BASE_IMAGE_URL:-}" M_SHA="${GITHUB_SHA:-}"
+
+python3 - "$OUT" <<'PYEOF'
+import json, os, sys
+env = os.environ
 manifest = {
-    "variant": "${VARIANT}",
-    "lang": "${LANG_CODE:-}",
-    "build_date": "${BUILD_DATE}",
-    "base_os": "${OS_PRETTY}",
-    "python_abi": "${PY_ABI}",
-    "constraints": "${CONSTRAINTS:-}",
-    "base_image_url": "${BASE_IMAGE_URL:-}",
-    "git_sha": "${GITHUB_SHA:-}",
-    "workflow_run": "${RUN_URL}",
-    "resolved_packages": ${FROZEN},
+    "variant": env["VARIANT"],
+    "lang": env["M_LANG"],
+    "build_date": env["M_BUILD_DATE"],
+    "base_os": env["M_OS_PRETTY"],
+    "python_abi": env["M_PY_ABI"],
+    "constraints": env["M_CONSTRAINTS"],
+    "base_image_url": env["M_BASE_URL"],
+    "git_sha": env["M_SHA"],
+    "workflow_run": env["M_RUN_URL"],
+    "resolved_packages": env["M_FROZEN"].splitlines(),
 }
 with open(sys.argv[1], "w") as f:
     json.dump(manifest, f, indent=2, sort_keys=True)


### PR DESCRIPTION
Self-review follow-up to #156.

contract: unchanged

- **Tier 2 chroot**: bind-mount /proc, /sys, /dev, /dev/pts before chrooting — without them python imports (multiprocessing, /dev/null) fail and the smoke-test job that gates every build would go red on its first real image. `cleanup_image`'s `umount -R` already tears them down.
- **Tier 3 allowlist**: strip comments/blank lines before `grep -vEf` — every allowlist line was a live regex, and a blank line would have matched (suppressed) ALL journal errors. Verified: real error survives filtering, allowlisted error is suppressed.
- **Manifest writer**: quoted heredoc + env passing kills the shell-into-python interpolation; verified with a hostile `"$(evil)` constraints value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)