### PR TITLE
fix: build ggwave from sdist — wheel host is gone

### DIFF
--- a/build_raspOVOS_base_lite.sh
+++ b/build_raspOVOS_base_lite.sh
@@ -174,10 +174,12 @@ source /home/$OVOS_USER/.venvs/ovos/bin/activate
 # Install additional Python dependencies within the virtual environment.
 uv pip install --no-progress wheel cython -c $CONSTRAINTS
 
-# Install ggwave in the virtual environment (prebuilt wheel matched to the
-# image's python ABI via wheels.txt; hard-fails on an unknown ABI).
-echo "Installing ggwave..."
-bash /mounted-github-repo/scripts/install_wheel.sh ggwave
+# Install ggwave from sdist — the prebuilt wheel host (whl.smartgic.io)
+# is gone (404). It is a small C++ extension; build-essential and
+# python3-dev are already installed, so building under emulation is
+# acceptable (~minutes).
+echo "Installing ggwave (from source)..."
+uv pip install --no-progress ggwave
 
 # Install OVOS dependencies in the virtual environment.
 echo "Installing OVOS..."

--- a/wheels.txt
+++ b/wheels.txt
@@ -4,5 +4,6 @@
 # bump must add a row here, never break silently at boot.
 #
 # Columns (whitespace-separated): package  abi  url
-ggwave  cp311  https://whl.smartgic.io/ggwave-0.4.2-cp311-cp311-linux_aarch64.whl
+# NOTE: ggwave is built from sdist in the image (its former wheel host,
+# whl.smartgic.io, is gone); only heavy builds belong here.
 llama-cpp-python  cp311  https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.2/llama_cpp_python-0.3.2-cp311-cp311-linux_aarch64.whl


### PR DESCRIPTION
First real CI build on the revived pipeline failed at ggwave: the whl.smartgic.io wheel URL now returns 404 (pre-existing rot — any rebuild since the host vanished would have failed the same way; the build hard-failed loudly exactly as designed).

ggwave is a small C++ extension and build-essential/python3-dev are already in the image, so it now builds from sdist. `wheels.txt` keeps only llama-cpp-python, whose GitHub release URL is verified live (HTTP 302→200).

contract: unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation of the `ggwave` dependency by building it from source when a compatible prebuilt package is unavailable.
  * Prevented image builds from failing due to missing architecture-specific wheels.

* **Chores**
  * Updated package build configuration to reflect the new installation approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->