### PR TITLE
fix: skip dangling unit alias symlinks in Tier 2

### DIFF
--- a/scripts/ci/chroot_checks.sh
+++ b/scripts/ci/chroot_checks.sh
@@ -65,6 +65,8 @@ fi
 # never installed (the vendoring-drift bug class).
 log "Verifying systemd unit Exec targets"
 while IFS= read -r unit; do
+    # skip dangling alias symlinks (dbus-org.*.service pointing at masked units)
+    [[ -e "$unit" ]] || continue
     exec_paths="$(grep -hoE '^Exec[a-zA-Z]*=-?[^ ]+' "$unit" | sed 's/^Exec[a-zA-Z]*=-?//' || true)"
     for p in $exec_paths; do
         [[ "$p" == /* ]] || continue


### PR DESCRIPTION
First real Tier 2 run produced grep noise on dbus-org.*.service alias symlinks pointing at masked units; skip non-resolving symlinks in the Exec-target sweep.

Note the run itself did its job: Tier 2 caught a REAL shipped dependency conflict (ovos-core 2.5.0a2 vs ovos-workshop 8.3.0a1) — upstream fix in OpenVoiceOS/OpenVoiceOS#23.

contract: unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)