### PR TITLE
fix: UV_PRERELEASE=allow in every uv invocation

### DIFF
--- a/build_raspOVOS_base_full.sh
+++ b/build_raspOVOS_base_full.sh
@@ -9,7 +9,7 @@ set -e
 : "${OVOS_USER:=ovos}"
 : "${CONSTRAINTS:=https://github.com/OpenVoiceOS/OpenVoiceOS/raw/refs/heads/main/constraints-alpha.txt}"
 # every uv/pip invocation is constrained, even ones missing an explicit -c
-export UV_CONSTRAINT="$CONSTRAINTS" PIP_CONSTRAINT="$CONSTRAINTS"
+export UV_CONSTRAINT="$CONSTRAINTS" PIP_CONSTRAINT="$CONSTRAINTS" UV_PRERELEASE=allow
 
 
 # Retrieve the GID of the 'ovos' group

--- a/build_raspOVOS_base_lite.sh
+++ b/build_raspOVOS_base_lite.sh
@@ -11,7 +11,7 @@ set -e
 : "${HOSTNAME:=raspOVOS}"
 : "${CONSTRAINTS:=https://github.com/OpenVoiceOS/OpenVoiceOS/raw/refs/heads/main/constraints-alpha.txt}"
 # every uv/pip invocation is constrained, even ones missing an explicit -c
-export UV_CONSTRAINT="$CONSTRAINTS" PIP_CONSTRAINT="$CONSTRAINTS"
+export UV_CONSTRAINT="$CONSTRAINTS" PIP_CONSTRAINT="$CONSTRAINTS" UV_PRERELEASE=allow
 
 
 # Rename the default 'pi' user if the current user is not 'pi'.

--- a/lang_builds/hybrid/build_raspOVOS_ca.sh
+++ b/lang_builds/hybrid/build_raspOVOS_ca.sh
@@ -15,7 +15,7 @@ bash /mounted-github-repo/lang_builds/lite/build_raspOVOS_ca.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang ca-ES --hybrid --male --platform rpi4

--- a/lang_builds/hybrid/build_raspOVOS_da.sh
+++ b/lang_builds/hybrid/build_raspOVOS_da.sh
@@ -16,7 +16,7 @@ bash /mounted-github-repo/lang_builds/lite/build_raspOVOS_da.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang da-DK --hybrid --male --platform rpi4

--- a/lang_builds/hybrid/build_raspOVOS_de.sh
+++ b/lang_builds/hybrid/build_raspOVOS_de.sh
@@ -16,7 +16,7 @@ bash /mounted-github-repo/lang_builds/lite/build_raspOVOS_de.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang de-DE --hybrid --male --platform rpi4

--- a/lang_builds/hybrid/build_raspOVOS_en.sh
+++ b/lang_builds/hybrid/build_raspOVOS_en.sh
@@ -16,7 +16,7 @@ bash /mounted-github-repo/lang_builds/lite/build_raspOVOS_en.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang en-US --hybrid --male --platform rpi4

--- a/lang_builds/hybrid/build_raspOVOS_es.sh
+++ b/lang_builds/hybrid/build_raspOVOS_es.sh
@@ -15,7 +15,7 @@ bash /mounted-github-repo/lang_builds/lite/build_raspOVOS_es.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang es-ES --hybrid --male --platform rpi4

--- a/lang_builds/hybrid/build_raspOVOS_eu.sh
+++ b/lang_builds/hybrid/build_raspOVOS_eu.sh
@@ -15,7 +15,7 @@ bash /mounted-github-repo/lang_builds/lite/build_raspOVOS_eu.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang eu-ES --hybrid --female --platform rpi4

--- a/lang_builds/hybrid/build_raspOVOS_fr.sh
+++ b/lang_builds/hybrid/build_raspOVOS_fr.sh
@@ -16,7 +16,7 @@ bash /mounted-github-repo/lang_builds/lite/build_raspOVOS_fr.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang fr-FR --hybrid --male --platform rpi4

--- a/lang_builds/hybrid/build_raspOVOS_gl.sh
+++ b/lang_builds/hybrid/build_raspOVOS_gl.sh
@@ -15,7 +15,7 @@ bash /mounted-github-repo/lang_builds/lite/build_raspOVOS_gl.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang gl-ES --hybrid --female --platform rpi4

--- a/lang_builds/hybrid/build_raspOVOS_it.sh
+++ b/lang_builds/hybrid/build_raspOVOS_it.sh
@@ -17,7 +17,7 @@ bash /mounted-github-repo/lang_builds/lite/build_raspOVOS_it.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang it-IT --hybrid --female --platform rpi4

--- a/lang_builds/hybrid/build_raspOVOS_mul.sh
+++ b/lang_builds/hybrid/build_raspOVOS_mul.sh
@@ -12,7 +12,7 @@ set -e
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Copying overlays..."
 sudo cp -rv /mounted-github-repo/overlays/en/* /

--- a/lang_builds/hybrid/build_raspOVOS_nl.sh
+++ b/lang_builds/hybrid/build_raspOVOS_nl.sh
@@ -14,7 +14,7 @@ bash /mounted-github-repo/lang_builds/lite/build_raspOVOS_nl.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang nl-NL --hybrid --male --platform rpi4

--- a/lang_builds/hybrid/build_raspOVOS_pt.sh
+++ b/lang_builds/hybrid/build_raspOVOS_pt.sh
@@ -14,7 +14,7 @@ bash /mounted-github-repo/lang_builds/lite/build_raspOVOS_pt.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang pt-PT --hybrid --male --platform rpi4

--- a/lang_builds/lite/build_raspOVOS_ca.sh
+++ b/lang_builds/lite/build_raspOVOS_ca.sh
@@ -12,7 +12,7 @@ set -e
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Copying overlays..."
 sudo cp -rv /mounted-github-repo/overlays/ca/* /

--- a/lang_builds/lite/build_raspOVOS_da.sh
+++ b/lang_builds/lite/build_raspOVOS_da.sh
@@ -10,7 +10,7 @@ set -e
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 # TODO - no wake word for "wake up"
 #echo "Copying overlays..."

--- a/lang_builds/lite/build_raspOVOS_de.sh
+++ b/lang_builds/lite/build_raspOVOS_de.sh
@@ -10,7 +10,7 @@ set -e
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Copying overlays..."
 sudo cp -rv /mounted-github-repo/overlays/de/* /

--- a/lang_builds/lite/build_raspOVOS_en.sh
+++ b/lang_builds/lite/build_raspOVOS_en.sh
@@ -10,7 +10,7 @@ set -e
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Copying overlays..."
 sudo cp -rv /mounted-github-repo/overlays/en/* /

--- a/lang_builds/lite/build_raspOVOS_es.sh
+++ b/lang_builds/lite/build_raspOVOS_es.sh
@@ -10,7 +10,7 @@ set -e
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Copying overlays..."
 sudo cp -rv /mounted-github-repo/overlays/es/* /

--- a/lang_builds/lite/build_raspOVOS_eu.sh
+++ b/lang_builds/lite/build_raspOVOS_eu.sh
@@ -10,7 +10,7 @@ set -e
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Copying overlays..."
 sudo cp -rv /mounted-github-repo/overlays/eu/* /

--- a/lang_builds/lite/build_raspOVOS_fr.sh
+++ b/lang_builds/lite/build_raspOVOS_fr.sh
@@ -10,7 +10,7 @@ set -e
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 # TODO - no wake word for "wake up"
 #echo "Copying overlays..."

--- a/lang_builds/lite/build_raspOVOS_gl.sh
+++ b/lang_builds/lite/build_raspOVOS_gl.sh
@@ -10,7 +10,7 @@ set -e
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Copying overlays..."
 sudo cp -rv /mounted-github-repo/overlays/gl/* /

--- a/lang_builds/lite/build_raspOVOS_it.sh
+++ b/lang_builds/lite/build_raspOVOS_it.sh
@@ -12,7 +12,7 @@ set -e
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Copying overlays..."
 sudo cp -rv /mounted-github-repo/overlays/it/* /

--- a/lang_builds/lite/build_raspOVOS_nl.sh
+++ b/lang_builds/lite/build_raspOVOS_nl.sh
@@ -10,7 +10,7 @@ set -e
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Copying overlays..."
 sudo cp -rv /mounted-github-repo/overlays/nl/* /

--- a/lang_builds/lite/build_raspOVOS_pt.sh
+++ b/lang_builds/lite/build_raspOVOS_pt.sh
@@ -10,7 +10,7 @@ set -e
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Copying overlays..."
 sudo cp -rv /mounted-github-repo/overlays/pt/* /

--- a/lang_builds/offline/build_raspOVOS_ca.sh
+++ b/lang_builds/offline/build_raspOVOS_ca.sh
@@ -15,7 +15,7 @@ bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_ca.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang ca-ES --offline --male --platform rpi5

--- a/lang_builds/offline/build_raspOVOS_da.sh
+++ b/lang_builds/offline/build_raspOVOS_da.sh
@@ -14,7 +14,7 @@ bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_da.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang de-DE --offline --male --platform rpi5

--- a/lang_builds/offline/build_raspOVOS_de.sh
+++ b/lang_builds/offline/build_raspOVOS_de.sh
@@ -14,7 +14,7 @@ bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_de.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang de-DE --offline --male --platform rpi5

--- a/lang_builds/offline/build_raspOVOS_en.sh
+++ b/lang_builds/offline/build_raspOVOS_en.sh
@@ -14,7 +14,7 @@ bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_en.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang en-US --offline --male --platform rpi5

--- a/lang_builds/offline/build_raspOVOS_es.sh
+++ b/lang_builds/offline/build_raspOVOS_es.sh
@@ -14,7 +14,7 @@ bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_es.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang es-ES --offline --male --platform rpi5

--- a/lang_builds/offline/build_raspOVOS_eu.sh
+++ b/lang_builds/offline/build_raspOVOS_eu.sh
@@ -14,7 +14,7 @@ bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_eu.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang eu-ES --offline --female --platform rpi5

--- a/lang_builds/offline/build_raspOVOS_fr.sh
+++ b/lang_builds/offline/build_raspOVOS_fr.sh
@@ -14,7 +14,7 @@ bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_fr.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang fr-FR --offline --male --platform rpi5

--- a/lang_builds/offline/build_raspOVOS_gl.sh
+++ b/lang_builds/offline/build_raspOVOS_gl.sh
@@ -14,7 +14,7 @@ bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_gl.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang gl-ES --offline --female --platform rpi5

--- a/lang_builds/offline/build_raspOVOS_it.sh
+++ b/lang_builds/offline/build_raspOVOS_it.sh
@@ -15,7 +15,7 @@ bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_it.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang it-IT --offline --female --platform rpi5

--- a/lang_builds/offline/build_raspOVOS_nl.sh
+++ b/lang_builds/offline/build_raspOVOS_nl.sh
@@ -14,7 +14,7 @@ bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_nl.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang n-NL --offline --male --platform rpi5

--- a/lang_builds/offline/build_raspOVOS_pt.sh
+++ b/lang_builds/offline/build_raspOVOS_pt.sh
@@ -14,7 +14,7 @@ bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_pt.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate
-export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}"
+export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRERELEASE=allow
 
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang pt-PT --offline --male --platform rpi5

--- a/overlays/base_ovos/usr/local/bin/ovos-update
+++ b/overlays/base_ovos/usr/local/bin/ovos-update
@@ -46,7 +46,7 @@ print_message "Using update tag: $TAG" "info"
 
 # Set the constraints file based on the tag
 CONSTRAINTS="https://github.com/OpenVoiceOS/OpenVoiceOS/raw/refs/heads/main/constraints-$TAG.txt"
-export UV_CONSTRAINT="$CONSTRAINTS" PIP_CONSTRAINT="$CONSTRAINTS"
+export UV_CONSTRAINT="$CONSTRAINTS" PIP_CONSTRAINT="$CONSTRAINTS" UV_PRERELEASE=allow
 
 # Print information about the constraints file
 print_message "Using constraints file: $CONSTRAINTS" "info"


### PR DESCRIPTION
Root-cause fix for the Tier 2 pip-check failure: the OVOS stack is all prerelease versions, and `uv pip install` calls without `--pre` (e.g. `wheel cython`, wheel installs) resolve in a different version universe than the `--pre` calls — which is how workshop got downgraded below ovos-core's requirement. `UV_PRERELEASE=allow` is now exported next to `UV_CONSTRAINT` in the base scripts, all 33 lang builds, and the shipped `ovos-update`, so every invocation resolves consistently regardless of flags. (Constraints files are auto-generated upstream and were never the bug — the manual-edit PR is closed.)

contract: unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package installation reliability by allowing compatible pre-release versions during system builds and updates.
  * Applied consistently across full, lite, hybrid, offline, and update workflows while preserving existing dependency constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->