### PR TITLE
fix(ci): boot the Tier 3 image via NVMe, not virtio

### DIFF
--- a/scripts/ci/qemu_boot_test.sh
+++ b/scripts/ci/qemu_boot_test.sh
@@ -72,12 +72,17 @@ trap 'set +e; [[ -n "${QEMU_PID:-}" ]] && kill "$QEMU_PID" 2>/dev/null; rm -rf "
 
 # --- boot ---
 log "Booting image in qemu (timeout ${BOOT_TIMEOUT}s), serial -> $SERIAL_LOG"
+# the Raspberry Pi kernel has no virtio drivers; it does build in nvme,
+# xhci-pci and usb-storage (Pi 4/5 boot media), so present the disk as NVMe
+# and the NIC as a USB device
 QEMU_ARGS=(
     -M virt -cpu cortex-a72 -smp 4 -m 2048
     -kernel "$WORK/kernel8.img"
-    -append "console=ttyAMA0 root=/dev/vda2 rootwait rw"
-    -drive "file=$WORK/disk.img,format=raw,if=virtio"
-    -netdev user,id=net0 -device virtio-net-device,netdev=net0
+    -append "console=ttyAMA0 root=/dev/nvme0n1p2 rootwait rw"
+    -drive "file=$WORK/disk.img,format=raw,if=none,id=disk0"
+    -device "nvme,drive=disk0,serial=raspovos"
+    -device qemu-xhci
+    -netdev user,id=net0 -device usb-net,netdev=net0
     -nographic -serial mon:stdio
 )
 [[ -n "$INITRD" ]] && QEMU_ARGS+=(-initrd "$INITRD")


### PR DESCRIPTION
Tier 3 run 29209587280 reached the initramfs but `ALERT! /dev/vda2 does not exist`. Inspection of the image's `modules.builtin`/initramfs shows the Pi kernel has **no virtio drivers at all**, while `nvme`, `xhci-pci`, `usb-storage` and `sd_mod` are built in (they're the Pi 4/5 boot-media drivers). Switch the qemu disk to an NVMe device (`root=/dev/nvme0n1p2`) and the user-mode NIC to `usb-net` behind `qemu-xhci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the aarch64 virtual machine boot test configuration.
  * Updated storage and networking emulation to improve compatibility and reliability during smoke tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->