### PR TITLE
fix: offline tier installs onnx-asr and phoonnx (#169)

### DIFF
--- a/lang_builds/offline/build_raspOVOS_ca.sh
+++ b/lang_builds/offline/build_raspOVOS_ca.sh
@@ -20,21 +20,11 @@ export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRE
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang ca-ES --offline --male --platform rpi5
 
-echo "Installing Citrinet plugin..."
-uv pip install --no-progress ovos-stt-plugin-citrinet -c $CONSTRAINTS
+echo "Installing onnx-asr STT plugin (selected by offline recommends)..."
+uv pip install --no-progress ovos-stt-plugin-onnx-asr -c $CONSTRAINTS
 
-echo "Downloading catalan citrinet model..."
-
-# TODO - Temporarily removed due to license reasons, to be restored later
-#python -c "from huggingface_hub import hf_hub_download; repo_id='projecte-aina/stt-ca-citrinet-512'; subfolder='onnx'; files=['model.onnx', 'tokenizer.spm', 'preprocessor.ts']; [print(f'Downloaded {file} to {hf_hub_download(repo_id=repo_id, filename=file, subfolder=subfolder)}') for file in files]"
-# since script was run as root, we need to move downloaded files
-#mkdir -p /home/ovos/.cache/huggingface/hub/
-#mv /root/.cache/huggingface/hub/models--projecte-aina--stt-ca-citrinet-512/ /home/ovos/.cache/huggingface/hub/models--projecte-aina--stt-ca-citrinet-512/
-
-python -c "from huggingface_hub import hf_hub_download; repo_id='neongeckocom/stt_ca_citrinet_512_gamma_0_25'; subfolder='onnx'; files=['model.onnx', 'tokenizer.spm', 'preprocessor.ts']; [print(f'Downloaded {file} to {hf_hub_download(repo_id=repo_id, filename=file, subfolder=subfolder)}') for file in files]"
-# since script was run as root, we need to move downloaded files
-mkdir -p /home/ovos/.cache/huggingface/hub/
-mv /root/.cache/huggingface/hub/models--neongeckocom--stt_ca_citrinet_512_gamma_0_25/ /home/ovos/.cache/huggingface/hub/models--neongeckocom--stt_ca_citrinet_512_gamma_0_25/
+echo "Installing phoonnx TTS plugin (selected by offline recommends)..."
+uv pip install --no-progress phoonnx -c $CONSTRAINTS
 
 echo "Ensuring permissions for $OVOS_USER user..."
 # Replace 1000:1000 with the correct UID:GID if needed

--- a/lang_builds/offline/build_raspOVOS_da.sh
+++ b/lang_builds/offline/build_raspOVOS_da.sh
@@ -19,6 +19,12 @@ export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRE
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang de-DE --offline --male --platform rpi5
 
+echo "Installing onnx-asr STT plugin (selected by offline recommends)..."
+uv pip install --no-progress ovos-stt-plugin-onnx-asr -c $CONSTRAINTS
+
+echo "Installing phoonnx TTS plugin (selected by offline recommends)..."
+uv pip install --no-progress phoonnx -c $CONSTRAINTS
+
 echo "Downloading base whisper model ..."
 python -c "from huggingface_hub import snapshot_download; repo_id = 'Systran/faster-whisper-base'; file_path = snapshot_download(repo_id=repo_id); print(f'Downloaded {repo_id}')"
 # since script was run as root, we need to move downloaded files

--- a/lang_builds/offline/build_raspOVOS_de.sh
+++ b/lang_builds/offline/build_raspOVOS_de.sh
@@ -19,14 +19,11 @@ export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRE
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang de-DE --offline --male --platform rpi5
 
-echo "Installing Citrinet plugin..."
-uv pip install --no-progress ovos-stt-plugin-citrinet -c $CONSTRAINTS
+echo "Installing onnx-asr STT plugin (selected by offline recommends)..."
+uv pip install --no-progress ovos-stt-plugin-onnx-asr -c $CONSTRAINTS
 
-echo "Downloading german citrinet model..."
-python -c "from huggingface_hub import hf_hub_download; repo_id='neongeckocom/stt_de_citrinet_512_gamma_0_25'; subfolder='onnx'; files=['model.onnx', 'tokenizer.spm', 'preprocessor.ts']; [print(f'Downloaded {file} to {hf_hub_download(repo_id=repo_id, filename=file, subfolder=subfolder)}') for file in files]"
-# since script was run as root, we need to move downloaded files
-mkdir -p /home/ovos/.cache/huggingface/hub/
-mv /root/.cache/huggingface/hub/models--neongeckocom--stt_de_citrinet_512_gamma_0_25/ /home/ovos/.cache/huggingface/hub/models--neongeckocom--stt_de_citrinet_512_gamma_0_25/
+echo "Installing phoonnx TTS plugin (selected by offline recommends)..."
+uv pip install --no-progress phoonnx -c $CONSTRAINTS
 
 echo "Ensuring permissions for $OVOS_USER user..."
 # Replace 1000:1000 with the correct UID:GID if needed

--- a/lang_builds/offline/build_raspOVOS_en.sh
+++ b/lang_builds/offline/build_raspOVOS_en.sh
@@ -19,14 +19,11 @@ export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRE
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang en-US --offline --male --platform rpi5
 
-echo "Installing Citrinet plugin..."
-uv pip install --no-progress ovos-stt-plugin-citrinet -c $CONSTRAINTS
+echo "Installing onnx-asr STT plugin (selected by offline recommends)..."
+uv pip install --no-progress ovos-stt-plugin-onnx-asr -c $CONSTRAINTS
 
-echo "Downloading english citrinet model..."
-python -c "from huggingface_hub import hf_hub_download; repo_id='neongeckocom/stt_en_citrinet_512_gamma_0_25'; subfolder='onnx'; files=['model.onnx', 'tokenizer.spm', 'preprocessor.ts']; [print(f'Downloaded {file} to {hf_hub_download(repo_id=repo_id, filename=file, subfolder=subfolder)}') for file in files]"
-# since script was run as root, we need to move downloaded files
-mkdir -p /home/ovos/.cache/huggingface/hub/
-mv /root/.cache/huggingface/hub/models--neongeckocom--stt_en_citrinet_512_gamma_0_25/ /home/ovos/.cache/huggingface/hub/models--neongeckocom--stt_en_citrinet_512_gamma_0_25/
+echo "Installing phoonnx TTS plugin (selected by offline recommends)..."
+uv pip install --no-progress phoonnx -c $CONSTRAINTS
 
 echo "Ensuring permissions for $OVOS_USER user..."
 # Replace 1000:1000 with the correct UID:GID if needed

--- a/lang_builds/offline/build_raspOVOS_es.sh
+++ b/lang_builds/offline/build_raspOVOS_es.sh
@@ -19,14 +19,11 @@ export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRE
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang es-ES --offline --male --platform rpi5
 
-echo "Installing Citrinet plugin..."
-uv pip install --no-progress ovos-stt-plugin-citrinet -c $CONSTRAINTS
+echo "Installing onnx-asr STT plugin (selected by offline recommends)..."
+uv pip install --no-progress ovos-stt-plugin-onnx-asr -c $CONSTRAINTS
 
-echo "Downloading spanish citrinet model..."
-python -c "from huggingface_hub import hf_hub_download; repo_id='Jarbas/stt_es_citrinet_512_onnx'; subfolder='onnx'; files=['model.onnx', 'tokenizer.spm', 'preprocessor.ts']; [print(f'Downloaded {file} to {hf_hub_download(repo_id=repo_id, filename=file, subfolder=subfolder)}') for file in files]"
-# since script was run as root, we need to move downloaded files
-mkdir -p /home/ovos/.cache/huggingface/hub/
-mv /root/.cache/huggingface/hub/models--Jarbas--stt_es_citrinet_512_onnx/ /home/ovos/.cache/huggingface/hub/models--Jarbas--stt_es_citrinet_512_onnx/
+echo "Installing phoonnx TTS plugin (selected by offline recommends)..."
+uv pip install --no-progress phoonnx -c $CONSTRAINTS
 
 echo "Ensuring permissions for $OVOS_USER user..."
 # Replace 1000:1000 with the correct UID:GID if needed

--- a/lang_builds/offline/build_raspOVOS_eu.sh
+++ b/lang_builds/offline/build_raspOVOS_eu.sh
@@ -19,6 +19,12 @@ export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRE
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang eu-ES --offline --female --platform rpi5
 
+echo "Installing onnx-asr STT plugin (selected by offline recommends)..."
+uv pip install --no-progress ovos-stt-plugin-onnx-asr -c $CONSTRAINTS
+
+echo "Installing phoonnx TTS plugin (selected by offline recommends)..."
+uv pip install --no-progress phoonnx -c $CONSTRAINTS
+
 echo "Downloading zuazo whisper model ..."
 python -c "from huggingface_hub import snapshot_download; repo_id = 'Jarbas/faster-whisper-base-eu-cv16'; file_path = snapshot_download(repo_id=repo_id); print(f'Downloaded {repo_id}')"
 # since script was run as root, we need to move downloaded files

--- a/lang_builds/offline/build_raspOVOS_fr.sh
+++ b/lang_builds/offline/build_raspOVOS_fr.sh
@@ -19,14 +19,11 @@ export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRE
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang fr-FR --offline --male --platform rpi5
 
-echo "Installing Citrinet plugin..."
-uv pip install --no-progress ovos-stt-plugin-citrinet -c $CONSTRAINTS
+echo "Installing onnx-asr STT plugin (selected by offline recommends)..."
+uv pip install --no-progress ovos-stt-plugin-onnx-asr -c $CONSTRAINTS
 
-echo "Downloading german citrinet model..."
-python -c "from huggingface_hub import hf_hub_download; repo_id='neongeckocom/stt_fr_citrinet_512_gamma_0_25'; subfolder='onnx'; files=['model.onnx', 'tokenizer.spm', 'preprocessor.ts']; [print(f'Downloaded {file} to {hf_hub_download(repo_id=repo_id, filename=file, subfolder=subfolder)}') for file in files]"
-# since script was run as root, we need to move downloaded files
-mkdir -p /home/ovos/.cache/huggingface/hub/
-mv /root/.cache/huggingface/hub/models--neongeckocom--stt_fr_citrinet_512_gamma_0_25/ /home/ovos/.cache/huggingface/hub/models--neongeckocom--stt_fr_citrinet_512_gamma_0_25/
+echo "Installing phoonnx TTS plugin (selected by offline recommends)..."
+uv pip install --no-progress phoonnx -c $CONSTRAINTS
 
 echo "Ensuring permissions for $OVOS_USER user..."
 # Replace 1000:1000 with the correct UID:GID if needed

--- a/lang_builds/offline/build_raspOVOS_gl.sh
+++ b/lang_builds/offline/build_raspOVOS_gl.sh
@@ -19,6 +19,12 @@ export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRE
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang gl-ES --offline --female --platform rpi5
 
+echo "Installing onnx-asr STT plugin (selected by offline recommends)..."
+uv pip install --no-progress ovos-stt-plugin-onnx-asr -c $CONSTRAINTS
+
+echo "Installing phoonnx TTS plugin (selected by offline recommends)..."
+uv pip install --no-progress phoonnx -c $CONSTRAINTS
+
 echo "Downloading zuazo whisper model ..."
 python -c "from huggingface_hub import snapshot_download; repo_id = 'Jarbas/faster-whisper-base-gl-cv13'; file_path = snapshot_download(repo_id=repo_id); print(f'Downloaded {repo_id}')"
 # since script was run as root, we need to move downloaded files

--- a/lang_builds/offline/build_raspOVOS_it.sh
+++ b/lang_builds/offline/build_raspOVOS_it.sh
@@ -20,14 +20,11 @@ export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRE
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang it-IT --offline --female --platform rpi5
 
-echo "Installing Italian Citrinet plugin..."
-uv pip install --no-progress ovos-stt-plugin-citrinet -c $CONSTRAINTS
+echo "Installing onnx-asr STT plugin (selected by offline recommends)..."
+uv pip install --no-progress ovos-stt-plugin-onnx-asr -c $CONSTRAINTS
 
-echo "Downloading Italian citrinet model..."
-python -c "from huggingface_hub import hf_hub_download; repo_id='neongeckocom/stt_it_citrinet_512_gamma_0_25'; subfolder='onnx'; files=['model.onnx', 'tokenizer.spm', 'preprocessor.ts']; [print(f'Downloaded {file} to {hf_hub_download(repo_id=repo_id, filename=file, subfolder=subfolder)}') for file in files]"
-# since script was run as root, we need to move downloaded files
-mkdir -p /home/ovos/.cache/huggingface/hub/
-mv /root/.cache/huggingface/hub/models--neongeckocom--stt_it_citrinet_512_gamma_0_25/ /home/ovos/.cache/huggingface/hub/models--neongeckocom--stt_it_citrinet_512_gamma_0_25/
+echo "Installing phoonnx TTS plugin (selected by offline recommends)..."
+uv pip install --no-progress phoonnx -c $CONSTRAINTS
 
 echo "Ensuring permissions for $OVOS_USER user..."
 # Replace 1000:1000 with the correct UID:GID if needed

--- a/lang_builds/offline/build_raspOVOS_nl.sh
+++ b/lang_builds/offline/build_raspOVOS_nl.sh
@@ -19,14 +19,11 @@ export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRE
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang n-NL --offline --male --platform rpi5
 
-echo "Installing Citrinet plugin..."
-uv pip install --no-progress ovos-stt-plugin-citrinet -c $CONSTRAINTS
+echo "Installing onnx-asr STT plugin (selected by offline recommends)..."
+uv pip install --no-progress ovos-stt-plugin-onnx-asr -c $CONSTRAINTS
 
-echo "Downloading dutch citrinet model..."
-python -c "from huggingface_hub import hf_hub_download; repo_id='neongeckocom/stt_nl_citrinet_512_gamma_0_25'; subfolder='onnx'; files=['model.onnx', 'tokenizer.spm', 'preprocessor.ts']; [print(f'Downloaded {file} to {hf_hub_download(repo_id=repo_id, filename=file, subfolder=subfolder)}') for file in files]"
-# since script was run as root, we need to move downloaded files
-mkdir -p /home/ovos/.cache/huggingface/hub/
-mv /root/.cache/huggingface/hub/models--neongeckocom--stt_nl_citrinet_512_gamma_0_25/ /home/ovos/.cache/huggingface/hub/models--neongeckocom--stt_nl_citrinet_512_gamma_0_25/
+echo "Installing phoonnx TTS plugin (selected by offline recommends)..."
+uv pip install --no-progress phoonnx -c $CONSTRAINTS
 
 echo "Ensuring permissions for $OVOS_USER user..."
 # Replace 1000:1000 with the correct UID:GID if needed

--- a/lang_builds/offline/build_raspOVOS_pt.sh
+++ b/lang_builds/offline/build_raspOVOS_pt.sh
@@ -19,14 +19,11 @@ export UV_CONSTRAINT="${CONSTRAINTS:-}" PIP_CONSTRAINT="${CONSTRAINTS:-}" UV_PRE
 echo "Configuring for target language..."
 /home/$OVOS_USER/.venvs/ovos/bin/ovos-config autoconfigure --lang pt-PT --offline --male --platform rpi5
 
-echo "Installing Citrinet plugin..."
-uv pip install --no-progress ovos-stt-plugin-citrinet -c $CONSTRAINTS
+echo "Installing onnx-asr STT plugin (selected by offline recommends)..."
+uv pip install --no-progress ovos-stt-plugin-onnx-asr -c $CONSTRAINTS
 
-echo "Downloading portuguese citrinet model..."
-python -c "from huggingface_hub import hf_hub_download; repo_id='neongeckocom/stt_pt_citrinet_512_gamma_0_25'; subfolder='onnx'; files=['model.onnx', 'tokenizer.spm', 'preprocessor.ts']; [print(f'Downloaded {file} to {hf_hub_download(repo_id=repo_id, filename=file, subfolder=subfolder)}') for file in files]"
-# since script was run as root, we need to move downloaded files
-mkdir -p /home/ovos/.cache/huggingface/hub/
-mv /root/.cache/huggingface/hub/models--neongeckocom--stt_pt_citrinet_512_gamma_0_25/ /home/ovos/.cache/huggingface/hub/models--neongeckocom--stt_pt_citrinet_512_gamma_0_25/
+echo "Installing phoonnx TTS plugin (selected by offline recommends)..."
+uv pip install --no-progress phoonnx -c $CONSTRAINTS
 
 echo "Ensuring permissions for $OVOS_USER user..."
 # Replace 1000:1000 with the correct UID:GID if needed

--- a/scripts/ci/imports.d/offline.txt
+++ b/scripts/ci/imports.d/offline.txt
@@ -8,3 +8,5 @@ ovos_config
 ovos_utils
 ggwave
 llama_cpp
+phoonnx
+ovos_stt_plugin_onnxasr


### PR DESCRIPTION
🤖 This PR was drafted by an AI assistant (opencode/big-pickle) under the
raspovos lane and is gated by the orchestrator. A human reviews and merges.

# Offline tier installs onnx-asr and phoonnx

## Why

The offline tier's `ovos-config autoconfigure` selects
`ovos-stt-plugin-onnx-asr` and `phoonnx` as its STT and TTS plugins.
Miro ruled on 2026-09-08 that the images install what the tier selects,
so the offline and hybrid images carry onnx-asr and phoonnx and the size
cost is accepted (issue #169).

The per-language offline build scripts did not follow this. They installed
`ovos-stt-plugin-citrinet` and downloaded its model, a plugin the offline
configuration never names. The `da`, `eu` and `gl` scripts installed no
STT plugin at all.

## What changed

Each offline script now installs the two selected plugins in place of the
citrinet plugin and its model download:

- `ovos-stt-plugin-onnx-asr` and `phoonnx` install on top of the hybrid
  image (which already carries the STT/TTS runtime).
- `da`, `eu`, `gl` gain the same two installs; they previously had no
  STT plugin.
- `scripts/ci/imports.d/offline.txt` gains `phoonnx` and
  `ovos_stt_plugin_onnxasr` so the Tier 2 chroot check verifies the two
  new plugins import inside the offline venv.

The citrinet model downloads are removed because they became dead weight:
nothing in the offline configuration selects citrinet.

## Resolution note

Under `OpenVoiceOS/constraints-alpha.txt` these resolve to
`phoonnx 1.91.1a1` and `ovos-stt-plugin-onnx-asr 0.6.0a1`. The strings a
tier writes are entry point names, not distributions: the package is
`phoonnx`, and `ovos-tts-plugin-phoonnx` is not a distribution on PyPI.

## Not in this PR

- Baking in the onnx-asr model and the phoonnx voice per language is the
  follow-up (Phase 5.2 in the revised roadmap). It needs the model matrix
  and Miro's sign-off on image size. Without those models the plugins are
  installed but have nothing to run offline.
- The hybrid tier's language-specific engines (piper, ahotts, cotovia,
  nos, mimic) and whether they stay as weight nothing selects. This
  decision is filed to Miro.
- Separate defects found in the same pass, filed for follow-up: `da`
  autoconfigures with `--lang de-DE` and `nl` with `--lang n-NL` (both
  wrong language tags).

## Verification

- `bash -n` passes on all 11 offline scripts.
- `ovos_stt_plugin_onnxasr` and `phoonnx` both import in the workspace
  venv (the two module names used in the Tier 2 assertion).
- Shellcheck runs in CI; it is not installed on this machine.
- Whether onnxruntime has aarch64 wheels for the rpi4/rpi5 targets is
  unproven. It must be proven on a built image before this is called done.
