### PR TITLE
fix: hybrid tier installs phoonnx, drops piper/ahotts/cotovia

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ The following plugins are used for all images:
 
 | image_type | stt-plugin               | tts-plugin             | m2v-intent-model             |
 |------------|--------------------------|------------------------|------------------------------|
-| offline    | ovos-stt-plugin-citrinet | ovos-tts-plugin-piper  | ovos-model2vec-intents-LaBSE |
-| hybrid     | ovos-stt-plugin-server   | ovos-tts-plugin-piper  | ovos-model2vec-intents-LaBSE |
+| offline    | ovos-stt-plugin-onnx-asr | ovos-tts-plugin-phoonnx| ovos-model2vec-intents-LaBSE |
+| hybrid     | ovos-stt-plugin-server   | ovos-tts-plugin-phoonnx| ovos-model2vec-intents-LaBSE |
 | online     | ovos-stt-plugin-server   | ovos-tts-plugin-server | N/A                          |
 
 ---
@@ -81,7 +81,9 @@ To get better performance, consider self-hosting your own [TTS](https://openvoic
 
 ### Language specific plugins and models
 
-The following language specific plugin configurations are used:
+The following language specific plugin configurations are used. Hybrid images
+install `phoonnx` for TTS in every language; the engines below are the
+language specific additions that ship in the images that carry them.
 
 | lang | tts-plugin                             |
 |------|-----------------------------------------|

--- a/docs/reference/variants.md
+++ b/docs/reference/variants.md
@@ -5,8 +5,8 @@
 | Variant | STT | TTS | Intent pipeline | Minimum hardware |
 |---------|-----|-----|-----------------|------------------|
 | lite | `ovos-stt-plugin-server` (public) | `ovos-tts-plugin-server` (public) | minimal | Pi 3 (might work) |
-| hybrid | `ovos-stt-plugin-server` (public) | on-device (piper) | balanced | Pi 4 |
-| offline | on-device (citrinet / fasterwhisper) | on-device (piper) | full | Pi 4/5, 4 GB+ RAM |
+| hybrid | `ovos-stt-plugin-server` (public) | on-device (`ovos-tts-plugin-phoonnx`) | balanced | Pi 4 |
+| offline | on-device (`ovos-stt-plugin-onnx-asr`) | on-device (phoonnx) | full | Pi 4/5, 4 GB+ RAM |
 
 Release names look like `raspOVOS-<lang>-bookworm-arm64-<variant>.img.xz`.
 `DEV`-prefixed releases are the untranslated base images the language
@@ -26,8 +26,7 @@ STT per language (offline variant):
 
 | lang | stt-plugin | model |
 |------|------------|-------|
-| en, es, ca, pt, de, it, nl, fr | ovos-stt-plugin-citrinet | per-language citrinet ONNX |
-| da, gl, eu | ovos-stt-plugin-fasterwhisper | per-language faster-whisper |
+| all | ovos-stt-plugin-onnx-asr | per-language onnx-asr |
 
 Intent models (`ovos-model2vec-intents-*`) are selected per language where
 trained; the multilingual LaBSE model is the fallback.

--- a/lang_builds/hybrid/build_raspOVOS_ca.sh
+++ b/lang_builds/hybrid/build_raspOVOS_ca.sh
@@ -40,6 +40,12 @@ cd /tmp/espeak-ng
 rm -rf /tmp/espeak-ng
 cd /home/$OVOS_USER/
 
+# hybrid autoconfigure selects phoonnx; install what the tier selects
+if [[ "${RASPOVOS_TIER:-hybrid}" != "offline" ]]; then
+    echo "Installing phoonnx TTS plugin (selected by hybrid autoconfigure)..."
+    uv pip install --no-progress phoonnx -c $CONSTRAINTS
+fi
+
 echo "Ensuring permissions for $OVOS_USER user..."
 # Replace 1000:1000 with the correct UID:GID if needed
 chown -R 1000:1000 /home/$OVOS_USER

--- a/lang_builds/hybrid/build_raspOVOS_da.sh
+++ b/lang_builds/hybrid/build_raspOVOS_da.sh
@@ -28,17 +28,24 @@ python -c "from huggingface_hub import hf_hub_download; repo_id='Jarbas/ovos-mod
 mkdir -p /home/ovos/.cache/huggingface/hub/
 mv /root/.cache/huggingface/hub/models--Jarbas--ovos-model2vec-intents-LaBSE/ /home/ovos/.cache/huggingface/hub/models--Jarbas--ovos-model2vec-intents-LaBSE/
 
-echo "Installing Piper TTS..."
-uv pip install --no-progress ovos-tts-plugin-piper -c $CONSTRAINTS
+# TTS engine per tier: offline keeps the Piper voice; hybrid installs what
+# autoconfigure selects (phoonnx).
+if [[ "${RASPOVOS_TIER:-hybrid}" == "offline" ]]; then
+    echo "Installing Piper TTS..."
+    uv pip install --no-progress ovos-tts-plugin-piper -c $CONSTRAINTS
 
-# download default piper voice for danish
-PIPER_DIR="/home/$OVOS_USER/.local/share/piper_tts"
-VOICE_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/da/da_DK/talesyntese/medium/da_DK-talesyntese-medium.onnx?download=true"
-CONFIG_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/da/da_DK/talesyntese/medium/da_DK-talesyntese-medium.onnx.json?download=true"
-mkdir -p "$PIPER_DIR"
-echo "Downloading voice from $VOICE_URL..."
-wget "$VOICE_URL" -P "$PIPER_DIR"
-wget "$CONFIG_URL" -P "$PIPER_DIR"
+    # download default piper voice for danish
+    PIPER_DIR="/home/$OVOS_USER/.local/share/piper_tts"
+    VOICE_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/da/da_DK/talesyntese/medium/da_DK-talesyntese-medium.onnx?download=true"
+    CONFIG_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/da/da_DK/talesyntese/medium/da_DK-talesyntese-medium.onnx.json?download=true"
+    mkdir -p "$PIPER_DIR"
+    echo "Downloading voice from $VOICE_URL..."
+    wget "$VOICE_URL" -P "$PIPER_DIR"
+    wget "$CONFIG_URL" -P "$PIPER_DIR"
+else
+    echo "Installing phoonnx TTS plugin (selected by hybrid autoconfigure)..."
+    uv pip install --no-progress phoonnx -c $CONSTRAINTS
+fi
 
 echo "Ensuring permissions for $OVOS_USER user..."
 # Replace 1000:1000 with the correct UID:GID if needed

--- a/lang_builds/hybrid/build_raspOVOS_de.sh
+++ b/lang_builds/hybrid/build_raspOVOS_de.sh
@@ -28,17 +28,24 @@ python -c "from huggingface_hub import hf_hub_download; repo_id='Jarbas/ovos-mod
 mkdir -p /home/ovos/.cache/huggingface/hub/
 mv /root/.cache/huggingface/hub/models--Jarbas--ovos-model2vec-intents-LaBSE/ /home/ovos/.cache/huggingface/hub/models--Jarbas--ovos-model2vec-intents-LaBSE/
 
-echo "Installing Piper TTS..."
-uv pip install --no-progress ovos-tts-plugin-piper -c $CONSTRAINTS
+# TTS engine per tier: offline keeps the Piper voice; hybrid installs what
+# autoconfigure selects (phoonnx).
+if [[ "${RASPOVOS_TIER:-hybrid}" == "offline" ]]; then
+    echo "Installing Piper TTS..."
+    uv pip install --no-progress ovos-tts-plugin-piper -c $CONSTRAINTS
 
-# download default piper voice for german
-PIPER_DIR="/home/$OVOS_USER/.local/share/piper_tts"
-VOICE_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/de/de_DE/thorsten/medium/de_DE-thorsten-medium.onnx?download=true"
-CONFIG_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/de/de_DE/thorsten/medium/de_DE-thorsten-medium.onnx.json?download=true"
-mkdir -p "$PIPER_DIR"
-echo "Downloading voice from $VOICE_URL..."
-wget "$VOICE_URL" -P "$PIPER_DIR"
-wget "$CONFIG_URL" -P "$PIPER_DIR"
+    # download default piper voice for german
+    PIPER_DIR="/home/$OVOS_USER/.local/share/piper_tts"
+    VOICE_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/de/de_DE/thorsten/medium/de_DE-thorsten-medium.onnx?download=true"
+    CONFIG_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/de/de_DE/thorsten/medium/de_DE-thorsten-medium.onnx.json?download=true"
+    mkdir -p "$PIPER_DIR"
+    echo "Downloading voice from $VOICE_URL..."
+    wget "$VOICE_URL" -P "$PIPER_DIR"
+    wget "$CONFIG_URL" -P "$PIPER_DIR"
+else
+    echo "Installing phoonnx TTS plugin (selected by hybrid autoconfigure)..."
+    uv pip install --no-progress phoonnx -c $CONSTRAINTS
+fi
 
 echo "Ensuring permissions for $OVOS_USER user..."
 # Replace 1000:1000 with the correct UID:GID if needed

--- a/lang_builds/hybrid/build_raspOVOS_en.sh
+++ b/lang_builds/hybrid/build_raspOVOS_en.sh
@@ -28,30 +28,37 @@ python -c "from huggingface_hub import hf_hub_download; repo_id='Jarbas/ovos-mod
 mkdir -p /home/ovos/.cache/huggingface/hub/
 mv /root/.cache/huggingface/hub/models--Jarbas--ovos-model2vec-intents-potion-32M/ /home/ovos/.cache/huggingface/hub/models--Jarbas--ovos-model2vec-intents-potion-32M/
 
-echo "Installing Piper TTS..."
-uv pip install --no-progress ovos-tts-plugin-piper -c $CONSTRAINTS
+# TTS engine per tier: offline keeps the Piper voice; hybrid installs what
+# autoconfigure selects (phoonnx).
+if [[ "${RASPOVOS_TIER:-hybrid}" == "offline" ]]; then
+    echo "Installing Piper TTS..."
+    uv pip install --no-progress ovos-tts-plugin-piper -c $CONSTRAINTS
 
-# TODO - compile minimal without bundled voices
-#echo "Installing Mimic TTS (for G2P)"
-#apt-get -y --no-install-recommends install gcc make pkg-config automake libtool libasound2-dev libicu-dev
-#MIMIC_VERSION=1.2.0.2
-#git clone --branch ${MIMIC_VERSION} https://github.com/MycroftAI/mimic.git --depth=1 /tmp/mimic
-#cd /tmp/mimic
-#./autogen.sh
-#./configure --with-audio=alsa --enable-shared --prefix="$(pwd)"
-#make
-#make install
-#rm -rf /tmp/mimic
-#uv pip install --no-progress ovos-tts-plugin-mimic -c $CONSTRAINTS
+    # TODO - compile minimal without bundled voices
+    #echo "Installing Mimic TTS (for G2P)"
+    #apt-get -y --no-install-recommends install gcc make pkg-config automake libtool libasound2-dev libicu-dev
+    #MIMIC_VERSION=1.2.0.2
+    #git clone --branch ${MIMIC_VERSION} https://github.com/MycroftAI/mimic.git --depth=1 /tmp/mimic
+    #cd /tmp/mimic
+    #./autogen.sh
+    #./configure --with-audio=alsa --enable-shared --prefix="$(pwd)"
+    #make
+    #make install
+    #rm -rf /tmp/mimic
+    #uv pip install --no-progress ovos-tts-plugin-mimic -c $CONSTRAINTS
 
-# download default piper voice for english  (change this for other languages)
-PIPER_DIR="/home/$OVOS_USER/.local/share/piper_tts"
-VOICE_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB/alan/medium/en_GB-alan-medium.onnx?download=true"
-CONFIG_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB/alan/medium/en_GB-alan-medium.onnx.json?download=true"
-mkdir -p "$PIPER_DIR"
-echo "Downloading voice from $VOICE_URL..."
-wget "$VOICE_URL" -P "$PIPER_DIR"
-wget "$CONFIG_URL" -P "$PIPER_DIR"
+    # download default piper voice for english  (change this for other languages)
+    PIPER_DIR="/home/$OVOS_USER/.local/share/piper_tts"
+    VOICE_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB/alan/medium/en_GB-alan-medium.onnx?download=true"
+    CONFIG_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB/alan/medium/en_GB-alan-medium.onnx.json?download=true"
+    mkdir -p "$PIPER_DIR"
+    echo "Downloading voice from $VOICE_URL..."
+    wget "$VOICE_URL" -P "$PIPER_DIR"
+    wget "$CONFIG_URL" -P "$PIPER_DIR"
+else
+    echo "Installing phoonnx TTS plugin (selected by hybrid autoconfigure)..."
+    uv pip install --no-progress phoonnx -c $CONSTRAINTS
+fi
 
 
 echo "Ensuring permissions for $OVOS_USER user..."

--- a/lang_builds/hybrid/build_raspOVOS_es.sh
+++ b/lang_builds/hybrid/build_raspOVOS_es.sh
@@ -26,19 +26,26 @@ python -c "from huggingface_hub import hf_hub_download; repo_id='Jarbas/ovos-mod
 mkdir -p /home/ovos/.cache/huggingface/hub/
 mv /root/.cache/huggingface/hub/models--Jarbas--ovos-model2vec-intents-roberta-large-bne/ /home/ovos/.cache/huggingface/hub/models--Jarbas--ovos-model2vec-intents-roberta-large-bne/
 
-echo "Installing AhoTTS"
-uv pip install --no-progress ovos-tts-plugin-ahotts
+# TTS engine per tier: offline keeps the AhoTTS + Piper voices; hybrid installs
+# what autoconfigure selects (phoonnx).
+if [[ "${RASPOVOS_TIER:-hybrid}" == "offline" ]]; then
+    echo "Installing AhoTTS"
+    uv pip install --no-progress ovos-tts-plugin-ahotts
 
-echo "Installing Piper TTS"
-uv pip install --no-progress ovos-tts-plugin-piper
+    echo "Installing Piper TTS"
+    uv pip install --no-progress ovos-tts-plugin-piper
 
-PIPER_DIR="/home/$OVOS_USER/.local/share/piper_tts"
-VOICE_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/es/es_ES/sharvard/medium/es_ES-sharvard-medium.onnx?download=true"
-CONFIG_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/es/es_ES/sharvard/medium/es_ES-sharvard-medium.onnx.json?download=true"
-mkdir -p "$PIPER_DIR"
-echo "Downloading voice from $VOICE_URL..."
-wget "$VOICE_URL" -P "$PIPER_DIR"
-wget "$CONFIG_URL" -P "$PIPER_DIR"
+    PIPER_DIR="/home/$OVOS_USER/.local/share/piper_tts"
+    VOICE_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/es/es_ES/sharvard/medium/es_ES-sharvard-medium.onnx?download=true"
+    CONFIG_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/es/es_ES/sharvard/medium/es_ES-sharvard-medium.onnx.json?download=true"
+    mkdir -p "$PIPER_DIR"
+    echo "Downloading voice from $VOICE_URL..."
+    wget "$VOICE_URL" -P "$PIPER_DIR"
+    wget "$CONFIG_URL" -P "$PIPER_DIR"
+else
+    echo "Installing phoonnx TTS plugin (selected by hybrid autoconfigure)..."
+    uv pip install --no-progress phoonnx -c $CONSTRAINTS
+fi
 
 echo "Ensuring permissions for $OVOS_USER user..."
 # Replace 1000:1000 with the correct UID:GID if needed

--- a/lang_builds/hybrid/build_raspOVOS_eu.sh
+++ b/lang_builds/hybrid/build_raspOVOS_eu.sh
@@ -26,8 +26,15 @@ python -c "from huggingface_hub import hf_hub_download; repo_id='Jarbas/ovos-mod
 mkdir -p /home/ovos/.cache/huggingface/hub/
 mv /root/.cache/huggingface/hub/models--Jarbas--ovos-model2vec-intents-BERnaT-base/ /home/ovos/.cache/huggingface/hub/models--Jarbas--ovos-model2vec-intents-BERnaT-base/
 
-echo "Installing AhoTTS"
-uv pip install --no-progress ovos-tts-plugin-ahotts
+# TTS engine per tier: offline keeps the AhoTTS voice; hybrid installs what
+# autoconfigure selects (phoonnx).
+if [[ "${RASPOVOS_TIER:-hybrid}" == "offline" ]]; then
+    echo "Installing AhoTTS"
+    uv pip install --no-progress ovos-tts-plugin-ahotts
+else
+    echo "Installing phoonnx TTS plugin (selected by hybrid autoconfigure)..."
+    uv pip install --no-progress phoonnx -c $CONSTRAINTS
+fi
 
 echo "Ensuring permissions for $OVOS_USER user..."
 # Replace 1000:1000 with the correct UID:GID if needed

--- a/lang_builds/hybrid/build_raspOVOS_fr.sh
+++ b/lang_builds/hybrid/build_raspOVOS_fr.sh
@@ -28,17 +28,24 @@ python -c "from huggingface_hub import hf_hub_download; repo_id='Jarbas/ovos-mod
 mkdir -p /home/ovos/.cache/huggingface/hub/
 mv /root/.cache/huggingface/hub/models--Jarbas--ovos-model2vec-intents-LaBSE/ /home/ovos/.cache/huggingface/hub/models--Jarbas--ovos-model2vec-intents-LaBSE/
 
-echo "Installing Piper TTS..."
-uv pip install --no-progress ovos-tts-plugin-piper -c $CONSTRAINTS
+# TTS engine per tier: offline keeps the Piper voice; hybrid installs what
+# autoconfigure selects (phoonnx).
+if [[ "${RASPOVOS_TIER:-hybrid}" == "offline" ]]; then
+    echo "Installing Piper TTS..."
+    uv pip install --no-progress ovos-tts-plugin-piper -c $CONSTRAINTS
 
-# download default piper voice for danish
-PIPER_DIR="/home/$OVOS_USER/.local/share/piper_tts"
-VOICE_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/fr/fr_FR/gilles/low/fr_FR-gilles-low.onnx?download=true"
-CONFIG_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/fr/fr_FR/gilles/low/fr_FR-gilles-low.onnx.json?download=true"
-mkdir -p "$PIPER_DIR"
-echo "Downloading voice from $VOICE_URL..."
-wget "$VOICE_URL" -P "$PIPER_DIR"
-wget "$CONFIG_URL" -P "$PIPER_DIR"
+    # download default piper voice for french
+    PIPER_DIR="/home/$OVOS_USER/.local/share/piper_tts"
+    VOICE_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/fr/fr_FR/gilles/low/fr_FR-gilles-low.onnx?download=true"
+    CONFIG_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/fr/fr_FR/gilles/low/fr_FR-gilles-low.onnx.json?download=true"
+    mkdir -p "$PIPER_DIR"
+    echo "Downloading voice from $VOICE_URL..."
+    wget "$VOICE_URL" -P "$PIPER_DIR"
+    wget "$CONFIG_URL" -P "$PIPER_DIR"
+else
+    echo "Installing phoonnx TTS plugin (selected by hybrid autoconfigure)..."
+    uv pip install --no-progress phoonnx -c $CONSTRAINTS
+fi
 
 echo "Ensuring permissions for $OVOS_USER user..."
 # Replace 1000:1000 with the correct UID:GID if needed

--- a/lang_builds/hybrid/build_raspOVOS_gl.sh
+++ b/lang_builds/hybrid/build_raspOVOS_gl.sh
@@ -34,8 +34,16 @@ mkdir -p /home/$OVOS_USER/.local/share/nos_tts_models/celtia
 wget https://huggingface.co/Jarbas/proxectonos-celtia-vits-graphemes-onnx/resolve/main/model.onnx -P /home/$OVOS_USER/.local/share/nos_tts_models/celtia
 wget https://huggingface.co/Jarbas/proxectonos-celtia-vits-graphemes-onnx/resolve/main/config.json -P /home/$OVOS_USER/.local/share/nos_tts_models/celtia
 
-# TODO local cotovia binary
-uv pip install --no-progress ovos-tts-plugin-cotovia ovos-tts-plugin-nos -c $CONSTRAINTS
+# TTS engines per tier: NOS voices ship in both tiers; cotovia stays on
+# offline; hybrid installs what autoconfigure selects (phoonnx).
+if [[ "${RASPOVOS_TIER:-hybrid}" == "offline" ]]; then
+    # TODO local cotovia binary
+    uv pip install --no-progress ovos-tts-plugin-cotovia ovos-tts-plugin-nos -c $CONSTRAINTS
+else
+    uv pip install --no-progress ovos-tts-plugin-nos -c $CONSTRAINTS
+    echo "Installing phoonnx TTS plugin (selected by hybrid autoconfigure)..."
+    uv pip install --no-progress phoonnx -c $CONSTRAINTS
+fi
 
 echo "Ensuring permissions for $OVOS_USER user..."
 # Replace 1000:1000 with the correct UID:GID if needed

--- a/lang_builds/hybrid/build_raspOVOS_it.sh
+++ b/lang_builds/hybrid/build_raspOVOS_it.sh
@@ -29,16 +29,24 @@ python -c "from huggingface_hub import hf_hub_download; repo_id='Jarbas/ovos-mod
 mkdir -p /home/ovos/.cache/huggingface/hub/
 mv /root/.cache/huggingface/hub/models--Jarbas--ovos-model2vec-intents-LaBSE/ /home/ovos/.cache/huggingface/hub/models--Jarbas--ovos-model2vec-intents-LaBSE/
 
-echo "Installing Piper TTS..."
-uv pip install --no-progress ovos-tts-plugin-piper -c $CONSTRAINTS
+# TTS engine per tier: offline keeps the Piper voice; hybrid installs what
+# autoconfigure selects (phoonnx).
+if [[ "${RASPOVOS_TIER:-hybrid}" == "offline" ]]; then
+    echo "Installing Piper TTS..."
+    uv pip install --no-progress ovos-tts-plugin-piper -c $CONSTRAINTS
 
-PIPER_DIR="/home/$OVOS_USER/.local/share/piper_tts"
-VOICE_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/it/it_IT/riccardo/x_low/it_IT-riccardo-x_low.onnx?download=true"
-CONFIG_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/it/it_IT/riccardo/x_low/it_IT-riccardo-x_low.onnx.json?download=true"
-mkdir -p "$PIPER_DIR"
-echo "Downloading voice from $VOICE_URL..."
-wget "$VOICE_URL" -P "$PIPER_DIR"
-wget "$CONFIG_URL" -P "$PIPER_DIR"
+    # download default piper voice for italian
+    PIPER_DIR="/home/$OVOS_USER/.local/share/piper_tts"
+    VOICE_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/it/it_IT/riccardo/x_low/it_IT-riccardo-x_low.onnx?download=true"
+    CONFIG_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/it/it_IT/riccardo/x_low/it_IT-riccardo-x_low.onnx.json?download=true"
+    mkdir -p "$PIPER_DIR"
+    echo "Downloading voice from $VOICE_URL..."
+    wget "$VOICE_URL" -P "$PIPER_DIR"
+    wget "$CONFIG_URL" -P "$PIPER_DIR"
+else
+    echo "Installing phoonnx TTS plugin (selected by hybrid autoconfigure)..."
+    uv pip install --no-progress phoonnx -c $CONSTRAINTS
+fi
 
 echo "Ensuring permissions for $OVOS_USER user..."
 # Replace 1000:1000 with the correct UID:GID if needed

--- a/lang_builds/hybrid/build_raspOVOS_nl.sh
+++ b/lang_builds/hybrid/build_raspOVOS_nl.sh
@@ -26,17 +26,24 @@ python -c "from huggingface_hub import hf_hub_download; repo_id='Jarbas/ovos-mod
 mkdir -p /home/ovos/.cache/huggingface/hub/
 mv /root/.cache/huggingface/hub/models--Jarbas--ovos-model2vec-intents-LaBSE/ /home/ovos/.cache/huggingface/hub/models--Jarbas--ovos-model2vec-intents-LaBSE/
 
-echo "Installing Piper TTS..."
-uv pip install --no-progress ovos-tts-plugin-piper -c $CONSTRAINTS
+# TTS engine per tier: offline keeps the Piper voice; hybrid installs what
+# autoconfigure selects (phoonnx).
+if [[ "${RASPOVOS_TIER:-hybrid}" == "offline" ]]; then
+    echo "Installing Piper TTS..."
+    uv pip install --no-progress ovos-tts-plugin-piper -c $CONSTRAINTS
 
-# download default piper voice for dutch
-PIPER_DIR="/home/$OVOS_USER/.local/share/piper_tts"
-VOICE_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/nl/nl_NL/ronnie/medium/nl_NL-ronnie-medium.onnx?download=true"
-CONFIG_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/nl/nl_NL/ronnie/medium/nl_NL-ronnie-medium.onnx.json?download=true"
-mkdir -p "$PIPER_DIR"
-echo "Downloading voice from $VOICE_URL..."
-wget "$VOICE_URL" -P "$PIPER_DIR"
-wget "$CONFIG_URL" -P "$PIPER_DIR"
+    # download default piper voice for dutch
+    PIPER_DIR="/home/$OVOS_USER/.local/share/piper_tts"
+    VOICE_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/nl/nl_NL/ronnie/medium/nl_NL-ronnie-medium.onnx?download=true"
+    CONFIG_URL="https://huggingface.co/rhasspy/piper-voices/resolve/main/nl/nl_NL/ronnie/medium/nl_NL-ronnie-medium.onnx.json?download=true"
+    mkdir -p "$PIPER_DIR"
+    echo "Downloading voice from $VOICE_URL..."
+    wget "$VOICE_URL" -P "$PIPER_DIR"
+    wget "$CONFIG_URL" -P "$PIPER_DIR"
+else
+    echo "Installing phoonnx TTS plugin (selected by hybrid autoconfigure)..."
+    uv pip install --no-progress phoonnx -c $CONSTRAINTS
+fi
 
 echo "Ensuring permissions for $OVOS_USER user..."
 # Replace 1000:1000 with the correct UID:GID if needed

--- a/lang_builds/hybrid/build_raspOVOS_pt.sh
+++ b/lang_builds/hybrid/build_raspOVOS_pt.sh
@@ -25,17 +25,24 @@ python -c "from huggingface_hub import hf_hub_download; repo_id='Jarbas/ovos-mod
 mkdir -p /home/ovos/.cache/huggingface/hub/
 mv /root/.cache/huggingface/hub/models--Jarbas--ovos-model2vec-intents-serafim-335m-portuguese-pt-sentence-encoder/ /home/ovos/.cache/huggingface/hub/models--Jarbas--ovos-model2vec-intents-serafim-335m-portuguese-pt-sentence-encoder/
 
-echo "Installing Piper TTS..."
-uv pip install --no-progress ovos-tts-plugin-piper -c $CONSTRAINTS
+# TTS engine per tier: offline keeps the Piper voice; hybrid installs what
+# autoconfigure selects (phoonnx).
+if [[ "${RASPOVOS_TIER:-hybrid}" == "offline" ]]; then
+    echo "Installing Piper TTS..."
+    uv pip install --no-progress ovos-tts-plugin-piper -c $CONSTRAINTS
 
-# download default piper voice for dutch
-PIPER_DIR="/home/$OVOS_USER/.local/share/piper_tts"
-VOICE_URL="https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/pt/pt_PT/tugão/medium/pt_PT-tugão-medium.onnx?download=true"
-CONFIG_URL="https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/pt/pt_PT/tugão/medium/pt_PT-tugão-medium.onnx.json?download=true"
-mkdir -p "$PIPER_DIR"
-echo "Downloading voice from $VOICE_URL..."
-wget "$VOICE_URL" -P "$PIPER_DIR"
-wget "$CONFIG_URL" -P "$PIPER_DIR"
+    # download default piper voice for portuguese
+    PIPER_DIR="/home/$OVOS_USER/.local/share/piper_tts"
+    VOICE_URL="https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/pt/pt_PT/tugão/medium/pt_PT-tugão-medium.onnx?download=true"
+    CONFIG_URL="https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/pt/pt_PT/tugão/medium/pt_PT-tugão-medium.onnx.json?download=true"
+    mkdir -p "$PIPER_DIR"
+    echo "Downloading voice from $VOICE_URL..."
+    wget "$VOICE_URL" -P "$PIPER_DIR"
+    wget "$CONFIG_URL" -P "$PIPER_DIR"
+else
+    echo "Installing phoonnx TTS plugin (selected by hybrid autoconfigure)..."
+    uv pip install --no-progress phoonnx -c $CONSTRAINTS
+fi
 
 echo "Ensuring permissions for $OVOS_USER user..."
 # Replace 1000:1000 with the correct UID:GID if needed

--- a/lang_builds/offline/build_raspOVOS_ca.sh
+++ b/lang_builds/offline/build_raspOVOS_ca.sh
@@ -11,7 +11,7 @@ set -e
 : "${CONSTRAINTS:=https://github.com/OpenVoiceOS/OpenVoiceOS/raw/refs/heads/main/constraints-alpha.txt}"
 
 # start from hybrid image
-bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_ca.sh
+RASPOVOS_TIER=offline bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_ca.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate

--- a/lang_builds/offline/build_raspOVOS_da.sh
+++ b/lang_builds/offline/build_raspOVOS_da.sh
@@ -10,7 +10,7 @@ set -e
 : "${CONSTRAINTS:=https://github.com/OpenVoiceOS/OpenVoiceOS/raw/refs/heads/main/constraints-alpha.txt}"
 
 # start from hybrid image
-bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_da.sh
+RASPOVOS_TIER=offline bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_da.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate

--- a/lang_builds/offline/build_raspOVOS_de.sh
+++ b/lang_builds/offline/build_raspOVOS_de.sh
@@ -10,7 +10,7 @@ set -e
 : "${CONSTRAINTS:=https://github.com/OpenVoiceOS/OpenVoiceOS/raw/refs/heads/main/constraints-alpha.txt}"
 
 # start from hybrid image
-bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_de.sh
+RASPOVOS_TIER=offline bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_de.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate

--- a/lang_builds/offline/build_raspOVOS_en.sh
+++ b/lang_builds/offline/build_raspOVOS_en.sh
@@ -10,7 +10,7 @@ set -e
 : "${CONSTRAINTS:=https://github.com/OpenVoiceOS/OpenVoiceOS/raw/refs/heads/main/constraints-alpha.txt}"
 
 # start from hybrid image
-bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_en.sh
+RASPOVOS_TIER=offline bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_en.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate

--- a/lang_builds/offline/build_raspOVOS_es.sh
+++ b/lang_builds/offline/build_raspOVOS_es.sh
@@ -10,7 +10,7 @@ set -e
 : "${CONSTRAINTS:=https://github.com/OpenVoiceOS/OpenVoiceOS/raw/refs/heads/main/constraints-alpha.txt}"
 
 # start from hybrid image
-bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_es.sh
+RASPOVOS_TIER=offline bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_es.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate

--- a/lang_builds/offline/build_raspOVOS_eu.sh
+++ b/lang_builds/offline/build_raspOVOS_eu.sh
@@ -10,7 +10,7 @@ set -e
 : "${CONSTRAINTS:=https://github.com/OpenVoiceOS/OpenVoiceOS/raw/refs/heads/main/constraints-alpha.txt}"
 
 # start from hybrid image
-bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_eu.sh
+RASPOVOS_TIER=offline bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_eu.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate

--- a/lang_builds/offline/build_raspOVOS_fr.sh
+++ b/lang_builds/offline/build_raspOVOS_fr.sh
@@ -10,7 +10,7 @@ set -e
 : "${CONSTRAINTS:=https://github.com/OpenVoiceOS/OpenVoiceOS/raw/refs/heads/main/constraints-alpha.txt}"
 
 # start from hybrid image
-bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_fr.sh
+RASPOVOS_TIER=offline bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_fr.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate

--- a/lang_builds/offline/build_raspOVOS_gl.sh
+++ b/lang_builds/offline/build_raspOVOS_gl.sh
@@ -10,7 +10,7 @@ set -e
 : "${CONSTRAINTS:=https://github.com/OpenVoiceOS/OpenVoiceOS/raw/refs/heads/main/constraints-alpha.txt}"
 
 # start from hybrid image
-bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_gl.sh
+RASPOVOS_TIER=offline bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_gl.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate

--- a/lang_builds/offline/build_raspOVOS_it.sh
+++ b/lang_builds/offline/build_raspOVOS_it.sh
@@ -11,7 +11,7 @@ set -e
 ## Intended to run on top of the raspOVOS FULL image
 
 # start from hybrid image
-bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_it.sh
+RASPOVOS_TIER=offline bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_it.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate

--- a/lang_builds/offline/build_raspOVOS_nl.sh
+++ b/lang_builds/offline/build_raspOVOS_nl.sh
@@ -10,7 +10,7 @@ set -e
 : "${CONSTRAINTS:=https://github.com/OpenVoiceOS/OpenVoiceOS/raw/refs/heads/main/constraints-alpha.txt}"
 
 # start from hybrid image
-bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_nl.sh
+RASPOVOS_TIER=offline bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_nl.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate

--- a/lang_builds/offline/build_raspOVOS_pt.sh
+++ b/lang_builds/offline/build_raspOVOS_pt.sh
@@ -10,7 +10,7 @@ set -e
 : "${CONSTRAINTS:=https://github.com/OpenVoiceOS/OpenVoiceOS/raw/refs/heads/main/constraints-alpha.txt}"
 
 # start from hybrid image
-bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_pt.sh
+RASPOVOS_TIER=offline bash /mounted-github-repo/lang_builds/hybrid/build_raspOVOS_pt.sh
 
 # Activate the virtual environment
 source /home/$OVOS_USER/.venvs/ovos/bin/activate

--- a/scripts/ci/imports.d/hybrid.txt
+++ b/scripts/ci/imports.d/hybrid.txt
@@ -6,3 +6,4 @@ ovos_gui
 ovos_bus_client
 ovos_config
 ovos_utils
+phoonnx


### PR DESCRIPTION
🤖 **This draft PR was authored by an AI agent (opencode/big-pickle).**

## What changes

The hybrid tier installs two TTS plugins that its autoconfiguration never
selects: piper and ahotts. It also installs cotovia for galician. The tier
now installs what it selects — `phoonnx` — in every language, and installs
the unselected engines only when a script runs as part of an offline build.

A tier configuration must agree with the packages it installs. We probed
`ovos-config autoconfigure --lang <lang> --hybrid --platform rpi5 --male`
for every language. Each one selects `ovos-tts-plugin-phoonnx` for TTS and
`ovos-stt-plugin-server` for STT.

## The shared-script gate

Every hybrid language script also runs first inside the matching offline
build (`lang_builds/offline/*.sh` starts from the hybrid image). Miro ruled
2026-09-08 that the removal must be gated on the tier when scripts are
shared. We implemented `RASPOVOS_TIER`:

- Values: `hybrid` (default) and `offline`.
- The hybrid build keeps the engine only when `RASPOVOS_TIER=offline`.
- The 11 offline scripts pass `RASPOVOS_TIER=offline` when they call the
  hybrid sibling, so the offline image keeps piper, ahotts, and cotovia
  exactly as it does today.
- A hybrid build (unset, the CI default) installs `phoonnx` and skips
  piper, ahotts, and cotovia.

## What changed per language

| lang | offline keeps | hybrid installs |
|------|---------------|-----------------|
| da de en fr it nl pt | piper + voice | phoonnx |
| es | piper + voice, ahotts | phoonnx |
| eu | ahotts | phoonnx |
| gl | cotovia + nos | nos + phoonnx |
| ca | matxa (unchanged) | phoonnx added; matxa kept |

`nos` (gl) and `matxa-multispeaker-cat` (ca) are not named by the ruling, so
they stay in both tiers. `mul` has no autoconfiguration and is untouched.

We also add `phoonnx` to the hybrid Tier-2 import list
(`scripts/ci/imports.d/hybrid.txt`). The chroot check imports it inside the
built image, which proves onnxruntime resolves on aarch64.

## Size delta (component-level, measured)

Miro asked for a measured size delta, not an estimate. A full image delta
needs `sudo` (QEMU build), which we do not have on this workstation. We
measured the removed and added components instead, each with a named
method:

### Removed piper voices (HF tree API, `rhasspy/piper-voices`)

| lang | bytes |
|------|-------|
| da | 63,206,506 |
| de | 63,206,398 |
| en | 63,206,502 |
| es | 76,738,910 |
| fr | 63,108,998 |
| it | 28,135,236 |
| nl | 62,955,364 |
| pt | 63,206,602 |

TOTAL = 483,764,516 B (~461 MiB, onnx + json + card files).

### Removed wheels (extracted bytes in a scratch venv against constraints-alpha.txt)

| package | bytes |
|---------|-------|
| ovos_tts_plugin_piper | 287,820 |
| ovos_tts_plugin_ahotts | 20,942 |
| pyahotts (ahotts runtime) | 30,842,661 |
| ovos_tts_plugin_cotovia | 33,540,244 |

### Added

| package | bytes |
|---------|-------|
| phoonnx (1.3.3, incl. dist-info) | 40,716,270 |
| phoonnx_train | 187,730 |

`onnxruntime` (~63 MB) stays: piper and phoonnx both depend on it. Its
aarch64 resolution is unproven before a built image and is part of what the
Tier-2 import check proves.

The numeric deltas above do not sum to a final image delta, because
`onnxruntime` and the ahotts/cotovia native binaries track
aarch64-vs-x86_64 wheel sizes. The authoritative delta is the built image,
gated in Tier 2.

## Docs

README tier table (offline/hybrid rows) and `docs/reference/variants.md`
now name `phoonnx` / `ovos-stt-plugin-onnx-asr` as the tier defaults, and
document that the language table lists extra engines still carried by the
images that install them.

## Provenance

Every plugin select above was run, not guessed:
`ovos-config autoconfigure` against the merged tree on `dev` at
`374f5f5`, and the size figures come from the HF tree API and a scratch
venv install against `constraints-alpha.txt`.